### PR TITLE
Don't raise missing file error if the input is a URL (http or https)

### DIFF
--- a/lib/ffmpeg/movie.rb
+++ b/lib/ffmpeg/movie.rb
@@ -9,7 +9,7 @@ module FFMPEG
     attr_reader :container
 
     def initialize(path)
-      raise Errno::ENOENT, "the file '#{path}' does not exist" unless File.exist?(path)
+      raise Errno::ENOENT, "the file '#{path}' does not exist" unless File.exist?(path)  || /^http/ === path
 
       @path = path
 


### PR DESCRIPTION
ffmpeg and ffprobe, both supports URL as an input. The current version of streamio rejects the input if it is not a local file. This PR should address that issue.
